### PR TITLE
Remove unneeded elements from Podfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ $ [sudo] gem install cocoapods
 To integrate Proposer into your Xcode project using CocoaPods, specify it in your `Podfile`:
 
 ```ruby
-source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
-use_frameworks!
 
 pod 'Proposer', '~> 0.6'
 ```


### PR DESCRIPTION
`source 'https://github.com/CocoaPods/Specs.git'` shouldn't be needed, it's the default one.

`use_frameworks!` frameworks are auto-used if there's a Swift pod.
